### PR TITLE
fix: Pin 3rd-party GitHub Actions to commit SHA digests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@2f8ba26a219c06cfb0f468eef8d97055fa814f97 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Optional: Configure Claude's behavior

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -36,10 +36,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -47,7 +47,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary
Pin all 3rd-party GitHub Actions to commit SHA digests for supply chain security.

### Actions Pinned
- `docker/setup-buildx-action@v3` → `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3`
- `docker/login-action@v3` → `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3`
- `docker/metadata-action@v5` → `docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5`
- `docker/build-push-action@v5` → `docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5`
- `anthropics/claude-code-action@v1` → `anthropics/claude-code-action@2f8ba26a219c06cfb0f468eef8d97055fa814f97 # v1`

### Workflows Updated
- `.github/workflows/docker-build-push.yml` (4 actions pinned)
- `.github/workflows/claude.yml` (1 action pinned)

## Test plan
- [ ] Verify CI workflows still run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned third-party GitHub Actions to immutable commit digests to harden CI supply chain security. Updated docker-build-push and claude workflows with no functional changes.

- **Dependencies**
  - Pinned: docker/setup-buildx-action v3, docker/login-action v3, docker/metadata-action v5, docker/build-push-action v5, anthropics/claude-code-action v1.
  - Added version comments for clarity.

<sup>Written for commit c2ed890dc662e59f7b7ebb6c68844eaea39f5d42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

